### PR TITLE
Rehat/coreos

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,3 +1,4 @@
+# Default params for locales
 class locales::params {
   $lc_ctype          = undef
   $lc_collate        = undef
@@ -48,9 +49,9 @@ class locales::params {
       $config_file = '/var/lib/locales/supported.d/local'
       $update_locale_pkg = false
       if $::operatingsystemmajrelease == '7' {
-           $default_file      = '/etc/locale.conf'
+        $default_file      = '/etc/locale.conf'
       } else {
-           $default_file      = '/etc/sysconfig/i18n'
+        $default_file      = '/etc/sysconfig/i18n'
       }
     }
     default: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,15 +16,16 @@ class locales::params {
 
   case $::operatingsystem {
     /(Ubuntu|Debian)/: {
-      $package           = 'locales'
+
       $default_file      = '/etc/default/locale'
       $locale_gen_cmd    = '/usr/sbin/locale-gen'
       $update_locale_cmd = '/usr/sbin/update-locale'
-      $supported_locales  = '/usr/share/i18n/SUPPORTED' # ALL locales support
+      $supported_locales = '/usr/share/i18n/SUPPORTED' # ALL locales support
 
-      case $::lsbdistid {
+      case $::operatingsystem {
         'Ubuntu': {
           $config_file = '/var/lib/locales/supported.d/local'
+          $package     = 'locales'
           case $::lsbdistcodename {
             'hardy': {
               $update_locale_pkg = 'belocs-locales-bin'
@@ -33,6 +34,16 @@ class locales::params {
               $update_locale_pkg = 'libc-bin'
             }
           }
+        }
+        'Debian' : {
+          $package = 'locales-all'
+          # If config_file is not set, we will end up with the error message:
+          # Missing title. The title expression resulted in undef at [init.pp
+          # at definition of file { $config_file: ]
+          # even if this resource is inside the branch of an if which will never
+          # be run.
+          $config_file = '/etc/locale.gen'
+          $update_locale_pkg = 'locales'
         }
         default: {
           $config_file = '/etc/locale.gen'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,7 +49,7 @@ class locales::params {
       $config_file = '/var/lib/locales/supported.d/local'
       $update_locale_pkg = false
       $local_generation_required = false
-      if $::operatingsystemmajrelease == 7 {
+      if $::operatingsystemmajrelease == '7' {
            $default_file      = '/etc/locale.conf'
       } else {
            $default_file      = '/etc/sysconfig/i18n'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,6 @@ class locales::params {
       $locale_gen_cmd    = '/usr/sbin/locale-gen'
       $update_locale_cmd = '/usr/sbin/update-locale'
       $supported_locales  = '/usr/share/i18n/SUPPORTED' # ALL locales support
-      $locale_generation_required = 'true'
 
       case $::lsbdistid {
         'Ubuntu': {
@@ -48,7 +47,6 @@ class locales::params {
       $update_locale_cmd = undef
       $config_file = '/var/lib/locales/supported.d/local'
       $update_locale_pkg = false
-      $local_generation_required = false
       if $::operatingsystemmajrelease == '7' {
            $default_file      = '/etc/locale.conf'
       } else {

--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,10 @@
     },
     {
       "operatingsystem": "Ubuntu"
-    }
+    },
+    {
+      "operatingsystem": "CentOS"
+    },
   ],
   "requirements": [
     {
@@ -27,9 +30,9 @@
   ],
   "description": "Manage locales on Linux",
   "types": [
-  
+
   ],
   "dependencies": [
-  
+
   ]
 }


### PR DESCRIPTION
Thanks for your work to make this module work under centos. I updated it, fixed a few details and tested it  under centos7 and jessie. 

The biggest issue for centos 7 was an int comparison with a string which failed (6 was OK I believe).

Debian had an annoying error where a variable was not set (by design) but puppet was not happy about it.

Now this module is valid for centos 6 & 7, Ubuntu and Debian.
