### PR TITLE
Remove trailing comma making metadata.json not parsable

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
     },
     {
       "operatingsystem": "CentOS"
-    },
+    }
   ],
   "requirements": [
     {


### PR DESCRIPTION
Sorry, I missed this debug message.
